### PR TITLE
Add spin persistence and redesign

### DIFF
--- a/script.js
+++ b/script.js
@@ -2,9 +2,19 @@ const wheel = document.getElementById('wheel');
 const spinButton = document.getElementById('spinButton');
 const editPanel = document.getElementById('editPanel');
 const spinAudio = document.getElementById('spinAudio');
-let prizes = ['Nagroda 1', 'Nagroda 2', 'Nagroda 3', 'Nagroda 4', 'booste'];
+
+let prizes = JSON.parse(localStorage.getItem('prizes')) || [
+    'Nagroda 1',
+    'Nagroda 2',
+    'Nagroda 3',
+    'Nagroda 4',
+    'booste'
+];
+let history = JSON.parse(localStorage.getItem('history')) || [];
+
 let angle = 0;
 let spinning = false;
+let spinStrength = 10;
 
 function drawWheel() {
     wheel.innerHTML = '<div class="pointer"></div>';
@@ -12,8 +22,15 @@ function drawWheel() {
     prizes.forEach((prize, i) => {
         const seg = document.createElement('div');
         seg.className = 'segment';
-        seg.textContent = prize;
         seg.style.transform = `rotate(${i * segAngle}deg) skewY(${90 - segAngle}deg)`;
+        seg.style.backgroundColor = `hsl(${i * (360 / prizes.length)},70%,40%)`;
+
+        const label = document.createElement('span');
+        label.className = 'label';
+        label.textContent = prize;
+        label.style.transform = `skewY(${-(90 - segAngle)}deg) rotate(${segAngle / 2}deg)`;
+
+        seg.appendChild(label);
         wheel.appendChild(seg);
     });
 }
@@ -26,17 +43,18 @@ function buildEditor() {
         input.addEventListener('change', e => {
             prizes[i] = e.target.value;
             drawWheel();
+            localStorage.setItem('prizes', JSON.stringify(prizes));
         });
         editPanel.appendChild(input);
     });
 }
 
 function spinWheel() {
-    if (spinning) return;
+    if (spinning || spinStrength <= 0) return;
     spinning = true;
     const segAngle = 360 / prizes.length;
     const rand = Math.floor(Math.random() * prizes.length);
-    const targetAngle = 3600 + rand * segAngle + segAngle / 2;
+    const targetAngle = spinStrength * 360 + rand * segAngle + segAngle / 2;
     angle = targetAngle;
     wheel.style.transform = `rotate(-${angle}deg)`;
     spinAudio.currentTime = 0;
@@ -48,7 +66,10 @@ function spinWheel() {
             confetti();
         }
         highlightSegment(rand);
+        history.push(result);
+        localStorage.setItem('history', JSON.stringify(history));
     }, 4000);
+    spinStrength = Math.max(0, spinStrength - 2);
 }
 
 function highlightSegment(index) {

--- a/style.css
+++ b/style.css
@@ -1,8 +1,11 @@
+@import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap');
+
 body {
     margin: 0;
-    font-family: Arial, sans-serif;
-    background: radial-gradient(#111, #000);
+    font-family: 'Press Start 2P', Arial, sans-serif;
+    background: radial-gradient(circle at center, #222, #000);
     color: #fff;
+    text-align: center;
 }
 .stage {
     position: relative;
@@ -13,6 +16,7 @@ body {
     flex-direction: column;
     align-items: center;
     justify-content: center;
+    background: radial-gradient(circle at center, #111, #000);
 }
 .neon {
     color: #0ff;
@@ -29,13 +33,15 @@ body {
 }
 .wheel {
     position: relative;
-    width: 400px;
-    height: 400px;
+    width: 450px;
+    height: 450px;
     border-radius: 50%;
-    border: 5px solid #0ff;
+    border: 8px solid #0ff;
+    box-shadow: 0 0 20px #0ff;
     overflow: hidden;
     transform: rotate(0deg);
     transition: transform 4s cubic-bezier(0.33, 1, 0.68, 1);
+    background: radial-gradient(circle, #444, #111);
 }
 .segment {
     position: absolute;
@@ -45,24 +51,44 @@ body {
     left: 50%;
     transform-origin: 0% 0%;
     display: flex;
-    align-items: center;
+    align-items: flex-end;
     justify-content: center;
-    background: #333;
     border: 1px solid #000;
+    color: #fff;
+    padding-bottom: 10px;
+    box-sizing: border-box;
+}
+
+.segment .label {
+    display: block;
+    font-size: 12px;
+    white-space: nowrap;
 }
 #spinButton {
     margin-top: 20px;
-    padding: 10px 20px;
-    font-size: 18px;
+    padding: 15px 30px;
+    font-size: 20px;
     cursor: pointer;
+    background: #0ff;
+    color: #000;
+    border: none;
+    border-radius: 5px;
+    box-shadow: 0 0 10px #0ff;
+    transition: box-shadow 0.3s;
+}
+
+#spinButton:hover {
+    box-shadow: 0 0 20px #0ff;
 }
 .edit-panel {
     position: absolute;
     bottom: 20px;
     left: 20px;
-    background: rgba(0,0,0,0.5);
+    background: rgba(0,0,0,0.7);
     padding: 10px;
     border: 1px solid #0ff;
+    box-shadow: 0 0 10px #0ff;
+    border-radius: 5px;
 }
 .edit-panel input {
     width: 100px;
@@ -70,14 +96,15 @@ body {
 }
 .pointer {
     position: absolute;
-    top: -20px;
+    top: -30px;
     left: 50%;
     transform: translateX(-50%);
     width: 0;
     height: 0;
-    border-left: 10px solid transparent;
-    border-right: 10px solid transparent;
-    border-bottom: 20px solid #f00;
+    border-left: 15px solid transparent;
+    border-right: 15px solid transparent;
+    border-bottom: 30px solid #f00;
+    filter: drop-shadow(0 0 5px #f00);
 }
 .highlight {
     background: #ff0;


### PR DESCRIPTION
## Summary
- load and save prizes & results in localStorage
- add spin weakening mechanic
- improve text orientation on wheel
- redesign the wheel and controls to look like a TV game show

## Testing
- `node -e "require('./script.js')"` *(fails: document undefined)*

------
https://chatgpt.com/codex/tasks/task_e_685322ad6380832fa1fb1312eb00242c