### PR TITLE
Improve wheel prizes and randomness

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # bc_wheel
 
 Prosty overlay HTML/CSS/JS przedstawiający koło z 5 polami do użycia na streamie.
+Domyślne pola to: **BOOSTER**, **KARTA**, **KOSZULKI**, **PUSZKA**, **PRZYPINKA**.
 
 ## Użycie
 1. Otwórz `index.html` w obsługiwanym przez OBS przeglądarce.
 2. Za pomocą przycisku **Kręć!** lub wywołując funkcję `onChatCommand('!spin')` rozpocznij losowanie.
 3. Pola koła można edytować w panelu w lewym dolnym rogu.
-4. Jeżeli wylosowane zostanie pole `booste`, pojawi się konfetti.
+4. Jeżeli wylosowane zostanie pole `BOOSTER`, pojawi się konfetti.
 5. Do pliku `spin.mp3` dodaj własny efekt dźwiękowy.
 
 Integrację z czatem YouTube należy zrealizować po stronie bota wywołującego funkcję `onChatCommand` po wykryciu komendy na czacie.

--- a/script.js
+++ b/script.js
@@ -4,11 +4,11 @@ const editPanel = document.getElementById('editPanel');
 const spinAudio = document.getElementById('spinAudio');
 
 let prizes = JSON.parse(localStorage.getItem('prizes')) || [
-    'Nagroda 1',
-    'Nagroda 2',
-    'Nagroda 3',
-    'Nagroda 4',
-    'booste'
+    'BOOSTER',
+    'KARTA',
+    'KOSZULKI',
+    'PUSZKA',
+    'PRZYPINKA'
 ];
 let history = JSON.parse(localStorage.getItem('history')) || [];
 
@@ -53,19 +53,22 @@ function spinWheel() {
     if (spinning || spinStrength <= 0) return;
     spinning = true;
     const segAngle = 360 / prizes.length;
+    const extraSpins = spinStrength + Math.floor(Math.random() * 5);
     const rand = Math.floor(Math.random() * prizes.length);
-    const targetAngle = spinStrength * 360 + rand * segAngle + segAngle / 2;
+    const randomOffset = Math.random() * segAngle;
+    const targetAngle = extraSpins * 360 + rand * segAngle + randomOffset;
     angle = targetAngle;
     wheel.style.transform = `rotate(-${angle}deg)`;
     spinAudio.currentTime = 0;
     spinAudio.play();
     setTimeout(() => {
         spinning = false;
-        const result = prizes[rand];
-        if (result.toLowerCase() === 'booste') {
+        const index = Math.floor((angle % 360) / segAngle) % prizes.length;
+        const result = prizes[index];
+        if (result.toLowerCase() === 'booster') {
             confetti();
         }
-        highlightSegment(rand);
+        highlightSegment(index);
         history.push(result);
         localStorage.setItem('history', JSON.stringify(history));
     }, 4000);

--- a/style.css
+++ b/style.css
@@ -16,7 +16,11 @@ body {
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    background: radial-gradient(circle at center, #111, #000);
+    background:
+        radial-gradient(circle at 50% 80%, rgba(255,255,255,0.2), rgba(0,0,0,0) 60%),
+        radial-gradient(circle at 20% 0%, rgba(255,0,0,0.4), rgba(0,0,0,0) 60%),
+        radial-gradient(circle at 80% 0%, rgba(0,0,255,0.4), rgba(0,0,0,0) 60%),
+        #111;
 }
 .neon {
     color: #0ff;


### PR DESCRIPTION
## Summary
- use giveaway names as default prizes
- randomize wheel spins more
- show confetti on BOOSTER
- enhance background with stage-style gradients

## Testing
- `npm test` *(fails: could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6853254eb990832fa252275d374743ec