### PR TITLE
Add TV show style spin wheel effects

### DIFF
--- a/script.js
+++ b/script.js
@@ -28,7 +28,7 @@ function drawWheel() {
         const label = document.createElement('span');
         label.className = 'label';
         label.textContent = prize;
-        label.style.transform = `skewY(${-(90 - segAngle)}deg) rotate(${segAngle / 2}deg)`;
+        label.style.transform = `skewY(${-(90 - segAngle)}deg) rotate(${segAngle / 2}deg) translateY(-80%)`;
 
         seg.appendChild(label);
         wheel.appendChild(seg);
@@ -53,6 +53,7 @@ function buildEditor() {
 function spinWheel() {
     if (spinning) return;
     spinning = true;
+    wheel.classList.add('spinning');
     const segAngle = 360 / prizes.length;
     const extraSpins = 2 + Math.floor(Math.random() * 4); // at least two full spins
     const rand = Math.floor(Math.random() * prizes.length);
@@ -64,6 +65,7 @@ function spinWheel() {
     spinAudio.play();
     setTimeout(() => {
         spinning = false;
+        wheel.classList.remove('spinning');
         const index = (prizes.length - Math.floor((angle % 360) / segAngle)) % prizes.length;
         const result = prizes[index];
         if (result.toLowerCase() === 'booster') {

--- a/style.css
+++ b/style.css
@@ -37,6 +37,51 @@ body {
     background: radial-gradient(circle, #666, #222);
 }
 
+.wheel.spinning {
+    box-shadow: inset 0 0 20px rgba(0,0,0,0.5), 0 0 25px #fff;
+}
+
+/* decorative shading and lights */
+.wheel::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    pointer-events: none;
+    background: radial-gradient(circle at 30% 30%, rgba(255,255,255,0.3), transparent 70%);
+}
+
+.wheel::after {
+    content: '';
+    position: absolute;
+    top: -15px;
+    left: -15px;
+    width: calc(100% + 30px);
+    height: calc(100% + 30px);
+    border-radius: 50%;
+    pointer-events: none;
+    background: repeating-conic-gradient(from 0deg, #ffd700 0deg 10deg, transparent 10deg 20deg);
+    filter: blur(2px) drop-shadow(0 0 5px #ffd700);
+    animation: rotateLights 20s linear infinite;
+    z-index: -1;
+}
+
+.wheel.spinning::after {
+    animation-duration: 2s;
+}
+
+@keyframes rotateLights {
+    from {
+        transform: rotate(0deg);
+    }
+    to {
+        transform: rotate(360deg);
+    }
+}
+
 .segment {
     position: absolute;
     width: 50%;
@@ -72,6 +117,12 @@ body {
     border-right: 15px solid transparent;
     border-top: 30px solid #f00;
     filter: drop-shadow(0 0 5px #f00);
+    animation: pointerBlink 1s infinite alternate;
+}
+
+@keyframes pointerBlink {
+    from { filter: drop-shadow(0 0 5px #f00); }
+    to { filter: drop-shadow(0 0 15px #ff0); }
 }
 
 #spinButton {


### PR DESCRIPTION
## Summary
- style wheel segments so labels stay inside the circle
- decorate the wheel with extra shading and animated lights
- make pointer blink for a game‑show effect
- highlight the wheel while spinning

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_685be211ea54832f807f307e3f947b43