### PR TITLE
Add static segments overlay to wheel

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,8 +12,9 @@
             <table id="resultsTable" class="results-table"></table>
             <div class="wheel-container">
                 <div id="resultText" class="result-text"></div>
-                <div id="pointer" class="pointer"></div>
+                <div id="segments" class="segments"></div>
                 <div id="wheel" class="wheel"></div>
+                <div id="pointer" class="pointer"></div>
             </div>
         </div>
         <button id="spinButton">Kręć!</button>

--- a/script.js
+++ b/script.js
@@ -5,6 +5,7 @@ const spinAudio = document.getElementById('spinAudio');
 const boosterAudio = document.getElementById('boosterAudio');
 const tshirtAudio = document.getElementById('tshirtAudio');
 const pointer = document.getElementById('pointer');
+const segmentsOverlay = document.getElementById('segments');
 const resultsTable = document.getElementById('resultsTable');
 const resultText = document.getElementById('resultText');
 const channel = new BroadcastChannel('wheel-sync');
@@ -66,6 +67,33 @@ function drawWheel() {
 
     wheel.appendChild(svg);
     updateResultsTable();
+    drawSegments();
+}
+
+function drawSegments() {
+    segmentsOverlay.innerHTML = '';
+    const segAngle = 360 / prizes.length;
+    const size = segmentsOverlay.clientWidth;
+    const radius = size / 2;
+    const svgNS = 'http://www.w3.org/2000/svg';
+    const svg = document.createElementNS(svgNS, 'svg');
+    svg.setAttribute('viewBox', `0 0 ${size} ${size}`);
+    svg.setAttribute('width', size);
+    svg.setAttribute('height', size);
+
+    for (let i = 0; i < prizes.length; i++) {
+        const angle = i * segAngle;
+        const x = radius + radius * Math.cos(angle * Math.PI / 180);
+        const y = radius + radius * Math.sin(angle * Math.PI / 180);
+        const line = document.createElementNS(svgNS, 'line');
+        line.setAttribute('x1', radius);
+        line.setAttribute('y1', radius);
+        line.setAttribute('x2', x);
+        line.setAttribute('y2', y);
+        svg.appendChild(line);
+    }
+
+    segmentsOverlay.appendChild(svg);
 }
 
 function buildEditor() {

--- a/style.css
+++ b/style.css
@@ -112,6 +112,21 @@ body {
     fill: #000;
 }
 
+.segments {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    z-index: 1;
+}
+
+.segments line {
+    stroke: rgba(255,255,255,0.8);
+    stroke-width: 2;
+}
+
 .pointer {
     position: absolute;
     top: -40px;
@@ -124,6 +139,7 @@ body {
     border-top: 30px solid #f00;
     filter: drop-shadow(0 0 5px #f00);
     animation: pointerBlink 1s infinite alternate;
+    z-index: 2;
 }
 
 .result-text {


### PR DESCRIPTION
## Summary
- keep segment dividers stationary while the wheel rotates
- style new segments overlay
- adjust DOM order and z-index for pointer

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685bf1d17a64832fbd2a1f0c743fed1e