### PR TITLE
Fix segment overlay rotation

### DIFF
--- a/script.js
+++ b/script.js
@@ -131,6 +131,7 @@ function spinWheel(remoteData = null) {
 
     angle += spinAngle;
     wheel.style.transform = `rotate(${angle}deg)`;
+    segmentsOverlay.style.transform = `rotate(${angle}deg)`;
     spinAudio.currentTime = 0;
     spinAudio.play();
     const result = prizes[index];
@@ -145,6 +146,7 @@ function spinWheel(remoteData = null) {
         localStorage.setItem('history', JSON.stringify(history));
         updateResultsTable();
         angle = angle % 360;
+        segmentsOverlay.style.transform = `rotate(${angle}deg)`;
     }, 4000);
 }
 

--- a/style.css
+++ b/style.css
@@ -120,6 +120,8 @@ body {
     height: 100%;
     pointer-events: none;
     z-index: 1;
+    transform: rotate(0deg);
+    transition: transform 4s cubic-bezier(0.33, 1, 0.68, 1);
 }
 
 .segments line {


### PR DESCRIPTION
## Summary
- animate the segment overlay together with the wheel
- sync final rotation value when the spin finishes

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685ce61613c0832f97f6caf8dc240b8f