### PR TITLE
Fix segment overlay rotation

### DIFF
--- a/script.js
+++ b/script.js
@@ -94,6 +94,8 @@ function drawSegments() {
     }
 
     segmentsOverlay.appendChild(svg);
+    // keep segment lines aligned with the wheel's current rotation
+    segmentsOverlay.style.transform = `rotate(${angle}deg)`;
 }
 
 function buildEditor() {

--- a/style.css
+++ b/style.css
@@ -120,7 +120,6 @@ body {
     height: 100%;
     pointer-events: none;
     z-index: 1;
-    transform: rotate(0deg);
     transition: transform 4s cubic-bezier(0.33, 1, 0.68, 1);
 }
 


### PR DESCRIPTION
## Summary
- keep segments overlay rotated with the wheel
- let JS control overlay rotation by removing fixed CSS transform

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685cee36b8fc832fb98cfebfb6096a4b