### PR TITLE
Ulepszenie animacji wskaźnika i czytelności napisów

### DIFF
--- a/script.js
+++ b/script.js
@@ -12,7 +12,7 @@ const pointerEl = document.getElementById('pointer');
 // Different fonts for each sector
 const prizeFonts = [
   'Impact, Charcoal, sans-serif',
-  'Comic Sans MS, cursive, sans-serif',
+  'Trebuchet MS, sans-serif',
   'Courier New, monospace',
   'Brush Script MT, cursive',
   'Papyrus, fantasy'
@@ -51,12 +51,13 @@ function drawWheel() {
 
     const mid = start + seg / 2;
     ctx.save();
-    ctx.translate(radius + (radius * 0.8) * Math.cos(mid), radius + (radius * 0.8) * Math.sin(mid));
+    const labelRadius = radius * 0.75;
+    ctx.translate(radius + labelRadius * Math.cos(mid), radius + labelRadius * Math.sin(mid));
     ctx.rotate(mid + Math.PI);
     ctx.fillStyle = '#fff';
     let fontSize = radius / 5;
     ctx.font = `bold ${fontSize}px ${prizeFonts[i % prizeFonts.length]}`;
-    const maxWidth = seg * radius * 0.8;
+    const maxWidth = seg * radius * 0.75;
     while (ctx.measureText(prizes[i]).width > maxWidth && fontSize > 10) {
       fontSize -= 1;
       ctx.font = `bold ${fontSize}px ${prizeFonts[i % prizeFonts.length]}`;

--- a/style.css
+++ b/style.css
@@ -33,7 +33,7 @@ body{
   border-right:10px solid transparent;
   border-top:40px solid red;
   filter:drop-shadow(0 0 5px red);
-  transform-origin:50% 100%;
+  transform-origin:50% 0%;
 }
 
 .pointer.hit{


### PR DESCRIPTION
## Podsumowanie
- wskaźnik obraca się teraz wokół górnej krawędzi, dzięki czemu wygląda jakby haczył o kołeczki
- napisy na kole są przesunięte nieco bliżej środka, aby nie stykały się z krawędzią
- wylosowane sektory nie używają czcionki Comic Sans

## Testy
- `npm test` *(oczekiwany błąd: brak `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_685cfe53d9b0832fa3fe9981e4d0e9c2